### PR TITLE
feat(helm-chart): Added support for Helm chart.

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 name: agent
 apiVersion: v2
 appVersion: 2.7.0
-version: 0.1.0
+version: 1.0.0-alpha
 description: Optimizely Agent - use Optimizely Full Stack and Rollouts with a microservice
 type: application
 keywords:

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,6 +1,6 @@
 name: agent
 apiVersion: v2
-appVersion: 1.3.0
+appVersion: 2.7.0
 version: 0.1.0
 description: Optimizely Agent - use Optimizely Full Stack and Rollouts with a microservice
 type: application

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,0 +1,18 @@
+name: agent
+apiVersion: v2
+appVersion: 1.3.0
+version: 0.1.0
+description: Optimizely Agent - use Optimizely Full Stack and Rollouts with a microservice
+type: application
+keywords:
+  - Optimizely
+  - Optimizely Agent
+  - Full Stack
+  - Rollouts
+  - Feature Flags
+home: https://docs.developers.optimizely.com/full-stack/docs/optimizely-agent
+sources: 
+    - https://github.com/optimizely/agent
+maintainers: 
+  - name: Optimizely Dev X Team
+    email: devx@optimizely.com

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2022 Optimizely
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,31 @@
+# Optimizely Agent Helm Chart
+
+The Optimizely Agent allows you to run a proxy to Optimizely in your own infrastructure, to help prevent adblockers from interfering with A/B tests. This repository contains a Helm chart to make it easy to host the Optimizely Agent in your own Kubernetes infrastructure.
+
+# Configurations
+
+|   Property	|  Description 	|
+|---	|---	|
+|replicaCount| Number of deployment replicas	|
+|image 	|Docker image to be used	|
+| autoscaling  	| To allow and configure autoscaling  	|
+| nameOverride  	|  Replaces the name of the chart in the Chart.yaml file 	|
+|fullnameOverride   	| Completely replaces the generated name  	|
+| serviceAccount  	| Specifies whether a service account should be created  	|
+| podAnnotations  	| A map with Kubernetes annotations  	|
+| podSecurityContext  	|  The security settings that you specify for a Pod apply to all Containers in the Pod 	|
+|   securityContext	|   The security settings that you specify for agent container	|
+|   env	| Environment variables and secrets  	|
+| service  	|  The type of network service to use and mapping of incoming ports to targetPorts |
+| ingress  	|  Exposes HTTP and HTTPS routes from outside the cluster to services within the cluster 	|
+|  nodeSelector 	|  To constrain Pods to nodes with specific labels 	|
+|  tolerations 	| Tolerations to apply to Pods  	|
+|  affinity 	| Sets the affinity Kubernetes attribute for Pods  	|
+|  config 	| Optimizely client instance configuration properties  	|
+
+## Links
+
+* <https://github.com/optimizely/agent>
+* <https://docs.developers.optimizely.com/full-stack/docs/optimizely-agent>
+* <https://hub.docker.com/r/optimizely/agent>
+* [Config file reference](https://github.com/optimizely/agent/blob/master/config.yaml)

--- a/README.md
+++ b/README.md
@@ -2,6 +2,15 @@
 
 The Optimizely Agent allows you to run a proxy to Optimizely in your own infrastructure, to help prevent adblockers from interfering with A/B tests. This repository contains a Helm chart to make it easy to host the Optimizely Agent in your own Kubernetes infrastructure.
 
+## Installation
+
+Add the following repo to use the chart:
+
+```console
+helm repo add optimizely-agent https://optimizely.github.io/optimizely-agent-helm
+helm install optimizely-agent
+```
+
 # Configurations
 
 |   Property	|  Description 	|

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Add the following repo to use the chart:
 
 ```console
 helm repo add optimizely-agent https://optimizely.github.io/optimizely-agent-helm
-helm install optimizely-agent
+helm install optimizely-agent optimizely-agent/optimizely-agent
 ```
 
 # Configurations

--- a/templates/NOTES.txt
+++ b/templates/NOTES.txt
@@ -1,0 +1,22 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "optimizely-agent.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "optimizely-agent.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "optimizely-agent.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "optimizely-agent.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+{{- end }}

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "optimizely-agent.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "optimizely-agent.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "optimizely-agent.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "optimizely-agent.labels" -}}
+helm.sh/chart: {{ include "optimizely-agent.chart" . }}
+{{ include "optimizely-agent.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "optimizely-agent.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "optimizely-agent.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "optimizely-agent.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "optimizely-agent.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/templates/config.yaml
+++ b/templates/config.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "{{ include "optimizely-agent.name" . }}-config"
+  labels:
+    {{- include "optimizely-agent.labels" . | nindent 4 }}
+data:
+  {{- range $k, $v := .Values.env.variables }}
+  {{ $k }}: {{ $v | quote }}
+  {{- end }}
+  config.yaml: |
+    {{- tpl .Values.config . | nindent 4 }}

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -1,0 +1,79 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "optimizely-agent.fullname" . }}
+  labels:
+    {{- include "optimizely-agent.labels" . | nindent 4 }}
+spec:
+{{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+{{- end }}
+  selector:
+    matchLabels:
+      {{- include "optimizely-agent.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+    {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+      labels:
+        {{- include "optimizely-agent.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      volumes:
+      - name: {{ include "optimizely-agent.name" . }}-config
+        configMap:
+          name: {{ include "optimizely-agent.name" . }}-config
+      serviceAccountName: {{ include "optimizely-agent.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          env:
+            - name: OPTIMIZELY_CONFIG_FILENAME
+              value: /etc/optimizely/config.yaml
+          envFrom:
+            - configMapRef:
+                name: {{ include "optimizely-agent.name" . }}-config
+            - secretRef:
+                name: {{ include "optimizely-agent.name" . }}-secrets
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            {{- range .Values.service.ports }}
+              - containerPort: {{ .targetPort }}
+                protocol: {{ .protocol }}
+                name: {{ .name }}
+            {{- end }}
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: api
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: api
+          volumeMounts:
+            - name: "{{ include "optimizely-agent.name" . }}-config"
+              mountPath: /etc/optimizely/config.yaml
+              subPath: config.yaml
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/templates/hpa.yaml
+++ b/templates/hpa.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "optimizely-agent.fullname" . }}
+  labels:
+    {{- include "optimizely-agent.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "optimizely-agent.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+  {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+  {{- end }}
+  {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}    
+  {{- end }}
+{{- end }}

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -1,0 +1,57 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "optimizely-agent.fullname" . -}}
+{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
+  {{- end }}
+{{- end }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "optimizely-agent.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path | quote }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ .port }}
+              {{- else }}
+              serviceName: {{ $fullName }}
+              servicePort: {{ .port }}
+              {{- end }}
+          {{- end }}
+    {{- end }}
+  {{- end }}

--- a/templates/secrets.yaml
+++ b/templates/secrets.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: "{{ include "optimizely-agent.name" . }}-secrets"
+type: Opaque
+data:
+  {{- range $k, $v := .Values.env.secrets }}
+  {{ $k }}: {{ $v | b64enc }}
+  {{- end }}

--- a/templates/service.yaml
+++ b/templates/service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "optimizely-agent.fullname" . }}
+  labels:
+    {{- include "optimizely-agent.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    {{- range .Values.service.ports }}
+     - port: {{ .port }}
+       protocol: {{ .protocol }}
+       name: {{ .name }}
+       targetPort: {{ .targetPort }}
+    {{- end }}
+  selector:
+    {{- include "optimizely-agent.selectorLabels" . | nindent 4 }}

--- a/templates/serviceaccount.yaml
+++ b/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "optimizely-agent.serviceAccountName" . }}
+  labels:
+    {{- include "optimizely-agent.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/templates/tests/test-connection.yaml
+++ b/templates/tests/test-connection.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "optimizely-agent.fullname" . }}-test-connection"
+  labels:
+    {{- include "optimizely-agent.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test-success
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['{{ include "optimizely-agent.fullname" . }}:{{ .Values.service.port }}']
+  restartPolicy: Never

--- a/values.yaml
+++ b/values.yaml
@@ -1,0 +1,290 @@
+# Default values for optimizely-agent.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 2
+
+image:
+  repository: optimizely/agent
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+podAnnotations: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+env:
+  variables: {}
+    # OPTIMIZELY_SDKKEYS: sdk_keys
+    # OPTIMIZELY_CLIENT_FLUSHINTERVAL: flush_interval
+  secrets: {}
+    # OPTIMIZELY_ADMIN_AUTH_HMACSECRETS: hmac_secrets
+    # OPTIMIZELY_API_AUTH_HMACSECRETS: hmac_secrets
+
+service:
+  type: NodePort
+  ports:
+   - port: 8080
+     protocol: TCP
+     name: api
+     targetPort: 8080
+   - port: 8085
+     protocol: TCP
+     name: webhook
+     targetPort: 8085
+   - port: 8088
+     protocol: TCP
+     name: admin
+     targetPort: 8088
+
+ingress:
+  enabled: false
+  # annotations: {}
+  # hosts:
+  #   - host: optimizely-agent.local
+  #     paths:
+  #     - port: 8080
+  #       path: /api
+  #       pathType: Prefix
+  #     - port: 8085
+  #       path: /webhook
+  #       pathType: Prefix
+  #     - port: 8088
+  #       path: /admin
+  #       pathType: Prefix
+  # tls: []
+
+resources: {} # set your own resources
+
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 100
+  targetCPUUtilizationPercentage: 80
+  targetMemoryUtilizationPercentage: 80
+
+nodeSelector: {}
+
+tolerations: []
+  # - key: "key1"
+  #   operator: "Equal"
+  #   value: "value1"
+  #   effect: "NoSchedule"
+
+
+affinity: {}
+
+logs:
+  level: debug
+  pretty: true
+  includeSdkKey: true
+
+# -- Config file contents
+# @default -- See https://github.com/optimizely/agent/blob/master/config.yaml
+config: |
+  ## config.yaml provides a default set of configuration options
+
+  ## service author included in the /info response
+  author: "Optimizely Inc."
+  ## name of the running application included in the /info response
+  name: "{{ include "optimizely-agent.fullname" . }}"
+  ## version of the application included in the /info response and startup logs
+  version: {{ .Chart.AppVersion }}
+
+  ## list of SDK keys to be pre-fetched during startup (recommended for production)
+  #sdkkeys:
+  #    - <sdk-key-1>
+  #    - <sdk-key-2>
+
+  ##
+  ## log: logger configuration
+  ##
+  log:
+      ## log level used to filter logs of lesser severity (from highest to lowest):
+      ## panic, fatal, error, warn, info, debug
+      level: {{ .Values.logs.level }}
+      ## enable pretty colorized console logging. setting to false will output
+      ## structured JSON logs. Recommended false in production.
+      pretty: {{ .Values.logs.pretty }}
+      ## to set whether or not the SDK key is included in the logging output.
+      includeSdkKey: {{ .Values.logs.includeSdkKey }}
+
+  ##
+  ## http server configuration
+  ##
+  server:
+      ## List of allowed request host values.
+      ## Requests whose host value does not match either the configured server.host, or one of these, will be rejected
+      ## with a 404 response.
+      ## To match all subdomains, you can use a leading dot (for example .example.com matches my.example.com, hello.world.example.com, etc.).
+      ## You can use the value "." to disable allowed host checking, allowing requests with any host.
+      ## Request host is determined in the following priority order:
+      ## 1. X-Forwarded-Host header value
+      ## 2. Forwarded header host= directive value
+      ## 3. Host property of request (see Host under https://golang.org/pkg/net/http/#Request)
+      ## Note: don't include port in these hosts values - port is stripped from the request host before comparing against these.
+      allowedHosts:
+          - "."
+      ## the maximum duration for reading the entire request, including the body.
+      ## Value can be set in seconds (e.g. "5s") or milliseconds (e.g. "5000ms")
+      readTimeout: 5s
+      ## the maximum duration before timing out writes of the response.
+      ## Value can be set in seconds (e.g. "5s") or milliseconds (e.g. "5000ms")
+      writeTimeout: 10s
+      ## path for the health status api
+      healthCheckPath: "/health"
+      ## the location of the TLS key file
+  #    keyFile: <key-file>
+      ## the location of the TLS certificate file
+  #    certFile: <cert-file>
+      ## IP of the host
+      host: "127.0.0.1"
+      ## configure optional Agent interceptors
+  #    interceptors:
+  #        httplog: {}
+
+  ##
+  ## api service configuration
+  ##
+  api:
+      ## the maximum number of concurrent requests handled by the api listener
+  #    maxConns: 10000
+      ## http listener port
+      {{ with index .Values.service.ports 0 }}
+      port: {{ .targetPort | quote }}
+      {{ end }}
+      ## set to true to enable subscribing to notifications via an SSE event-stream
+      enableNotifications: false
+      ## set to true to be able to override experiment bucketing. (recommended false in production)
+      enableOverrides: true
+      ## CORS support is provided via chi middleware
+      ## https://github.com/go-chi/cors
+  #    cors:
+  #      ## If allowedOrigins is nil or empty, value is set to ["*"].
+  #      allowedOrigins: ["*"]
+  #      ## If allowedMethods is nil or empty, value is set to (HEAD, GET and POST).
+  #      allowedMethods:
+  #      - "HEAD"
+  #      - "GET"
+  #      - "POST"
+  #      - "OPTIONS"
+  #      ## Default value is [] but "Origin" is always appended to the list.
+  #      allowedHeaders: ["*"]
+  #      exposedHeaders: []
+  #      allowedCredentials: false
+  #      maxAge: 300
+
+  ##
+  ## admin service configuration
+  ##
+  admin:
+      ## http listener port
+      {{ with index .Values.service.ports 2 }}
+      port: {{ .targetPort | quote }}
+      {{ end }}
+  ##
+  ## webhook service receives update notifications to your Optimizely project. Receipt of the webhook will
+  ## trigger an immediate download of the datafile from the CDN
+  ##
+  webhook:
+      ## http listener port
+      {{ with index .Values.service.ports 1 }}
+      port: {{ .targetPort | quote }}
+      {{ end }}
+  #    ## a map of Optimizely Projects to one or more SDK keys
+  #    projects:
+  #        ## <project-id>: Optimizely project id as an integer
+  #        <project-id>:
+  #            ## sdkKeys: a list of SDKs linked to this project
+  #            sdkKeys:
+  #                - <sdk-key-1>
+  #                - <sdk-key-1>
+  #            ## secret: webhook secret used the validate the notification
+  #            secret: <secret-10000>
+  #            ## skipSignatureCheck: override the signature check (not recommended for production)
+  #            skipSignatureCheck: true
+
+  ##
+  ## optimizely client configurations (options passed to the underlying go-sdk)
+  ##
+  client:
+      ## the time between successive polls for updated project configuration
+      pollingInterval: 1m
+      ## the number of events in a batch
+      batchSize: 10
+      ## the max number of events pending dispatch, setting this too low may result in events being dropped
+      queueSize: 1000
+      ## the maximum time between events being dispatched
+      flushInterval: 30s
+      ## Template URL for SDK datafile location. The template should specify a "%s" token for SDK key substitution.
+      datafileURLTemplate: "https://cdn.optimizely.com/datafiles/%s.json"
+      ## URL for dispatching events.
+      eventURL: "https://logx.optimizely.com/v1/events"
+      ## Validation Regex on the request SDK Key
+      ## By default Agent assumes only alphanumeric characters as part of the SDK Key string.
+      ## https://github.com/google/re2/wiki/Syntax
+      sdkKeyRegex: "^\\w+(:\\w+)?$"
+      ## configure optional User profile service
+      userProfileService:
+        default: ""
+        services:
+          # in-memory: 
+          #   capacity: 0
+          #   storageStrategy: "fifo"
+          # redis: 
+          #   host: "localhost:6379"
+          #   password: ""
+          #   database: 0
+          # rest: 
+          #   host: "http://localhost"
+          #   lookupPath: "/ups/lookup"
+          #   lookupMethod: "POST"
+          #   savePath: "/ups/save"
+          #   saveMethod: "POST"
+          #   userIDKey: "user_id"
+          #   headers: 
+          #     Content-Type: "application/json"
+          #     Auth-Token: "12345"
+
+  ##
+  ## optimizely runtime configuration can be used for debugging and profiling the go runtime.
+  ## These should only be configured when debugging in a non-production environment.
+  ##
+  runtime:
+      ## SetBlockProfileRate controls the fraction of goroutine blocking events
+      ## that are reported in the blocking profile. The profiler aims to sample
+      ## an average of one blocking event per rate nanoseconds spent blocked.
+      ##
+      ## To include every blocking event in the profile, pass rate = 1.
+      ## To turn off profiling entirely, pass rate <= 0.
+      blockProfileRate: 0
+
+      ## mutexProfileFraction controls the fraction of mutex contention events
+      ## that are reported in the mutex profile. On average 1/rate events are
+      ## reported. The previous rate is returned.
+      ##
+      ## To turn off profiling entirely, pass rate 0.
+      ## To just read the current rate, pass rate < 0.
+      ## (For n>1 the details of sampling may change.)
+      mutexProfileFraction: 0


### PR DESCRIPTION
## Background
This PR has some contribution from the following.
1. [PR-265](https://github.com/optimizely/agent/pull/265) contributed by [deathweaselx86](https://github.com/deathweaselx86).
2. [optimizely-agent-helm](https://github.com/kieranajp/optimizely-agent-helm) contributed by [kieranajp](https://github.com/kieranajp).

## Summary
- This PR has the support of the following features for optimizely-agent. 
- multiple agent servers can be up using replication set. 
- based on load,  pods can be added and removed via HPA. 
- support for DNS name using ingress. 
- env variable support using secrets & configmaps.

## ISSUES
- https://github.com/optimizely/agent/issues/167
- https://github.com/optimizely/agent/issues/319